### PR TITLE
Treat question.category.document as an Object, rather than an array

### DIFF
--- a/src/templates/faq.js
+++ b/src/templates/faq.js
@@ -67,7 +67,7 @@ class FrequentlyAskedQuestions extends Component {
     }
     if (activeCategory) {
       visibleQuestions = visibleQuestions.filter((faqItem) => {
-        const thisCategory = faqItem.category.document[0].data.categoryName.text;
+        const thisCategory = faqItem.category.document[0].data.categoryName.text || faqItem.category.document.data.categoryName.text;
         return activeCategory === thisCategory;
       });
     }
@@ -109,7 +109,7 @@ class FrequentlyAskedQuestions extends Component {
     };
     const bannerTitle = pageTitle && pageTitle.text ? pageTitle.text : 'Frequently Asked Questions';
     const bannerSubtitle = heroSubtitle && heroSubtitle.text ? heroSubtitle.text : 'You have questions, we have answers';
-    const categories = questions.map(((faqItem) => faqItem.category.document.data.categoryName.text));
+    const categories = questions.map(((faqItem) => faqItem.category.document[0].data.categoryName.text || faqItem.category.document.data.categoryName.text));
     const uniqueCategories = [...new Set(categories)];
     const faqSchemaData = questions && questions.length > 0 && questions.map((questionItem) => {
       const {

--- a/src/templates/faq.js
+++ b/src/templates/faq.js
@@ -109,7 +109,7 @@ class FrequentlyAskedQuestions extends Component {
     };
     const bannerTitle = pageTitle && pageTitle.text ? pageTitle.text : 'Frequently Asked Questions';
     const bannerSubtitle = heroSubtitle && heroSubtitle.text ? heroSubtitle.text : 'You have questions, we have answers';
-    const categories = questions.map(((faqItem) => faqItem.category.document[0].data.categoryName.text));
+    const categories = questions.map(((faqItem) => faqItem.category.document.data.categoryName.text));
     const uniqueCategories = [...new Set(categories)];
     const faqSchemaData = questions && questions.length > 0 && questions.map((questionItem) => {
       const {


### PR DESCRIPTION
I set up my prismic instance according to the instructions, however I found that my page wouldn't render until I made the following change.

I printed out the `questions` array and found that `document` was an object instead of an array of objects.

This may be specific to my setup, but it helped me.